### PR TITLE
fix(server): close DEFAULT_SITES array to fix SyntaxError on startup

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@ app.use(express.static('public'));
 // 默认接口配置 (保持你的 30+ 个接口不变)
 const DEFAULT_SITES = [
     { key: "ffzy", name: "非凡影视", api: "https://替换接口 一行一条", active: true },
+];
 
 if (!fs.existsSync(DATA_FILE) || FORCE_UPDATE) {
     // 只有在没有文件时，或者强制更新开启时，才重置配置


### PR DESCRIPTION
DEFAULT_SITES 数组缺少闭合 ];，会导致 Node 在解析时出现 SyntaxError: Unexpected token 'if'，服务无法启动。本提交补上 ]; 以修复语法错误。